### PR TITLE
Add a Makefile and a README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+DOCUMENT = ofj-template
+FLAGS    = -pdf -halt-on-error
+
+.PHONY:all continuously clean
+
+all:
+	latexmk ${FLAGS} ${DOCUMENT}.tex
+
+continuously:
+	latexmk ${FLAGS} -pvc ${DOCUMENT}.tex
+
+clean:
+	latexmk -C ${FLAGS} ${DOCUMENT}.tex
+	rm -fv ${DOCUMENT}.bbl

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# OpenFOAM Journal: LaTeX Template
+
+This is the official LaTeX Template for the [OpenFOAM Journal](https://journal.openfoam.com/).
+
+## Building
+
+On a Linux system, you can build the template from your terminal:
+
+```shell
+make
+```
+
+This will build `ofj-template.pdf` from `ofj-template.tex` once, using [latexmk](https://www.ctan.org/pkg/latexmk/).
+
+While writing your publication, you may prefer to continuously build it with
+
+```shell
+make continuously
+```
+
+which passes the `-pvc` flag to latexmk.


### PR DESCRIPTION
Hi there! :smile: :wave: I have collected several suggestions that I would like to contribute to this template. I will try to keep them small and well-documented, to accelerate the code reviews. :runner: 

In my first contribution, I am trying to solve the basic question _"what can I do after I download the template"_?

As a user, I would expect:
- A `README.md` file with all the information I need to get started.
- A `Makefile` (as I am on a Linux system), so that I can just type `make`, without even reading the documentation.

Going one step further, I have included a target to `make continuously`. This is extremely useful when actually writing a publication: one can only save changes to a file, and it is automatically built in the background.

I have deliberately kept the introduced files very simple, so that one can easily build upon them. Specifically for the `README.md`, I assume there is a lot more you would like to document there. But for now, I have only added the absolutely necessary parts.