### PR TITLE
Add continuous integration builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: tumi5/latex
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Install additional fonts # Only to make the MnSymbol in tensorNotation.sty work
+      run: apt-get update && apt-get install -y texlive-fonts-extra
+    - name: Build template
+      run: make
+    - name: Upload log files, if building failed
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: log files
+        path: ofj-template.log
+    - name: Upload resulting PDF
+      uses: actions/upload-artifact@v3
+      with:
+        name: template pdf
+        path: |
+          ofj-template.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+DOCUMENT = ofj-template
+FLAGS    = -pdf -halt-on-error
+
+.PHONY:all continuously clean
+
+all:
+	latexmk ${FLAGS} ${DOCUMENT}.tex
+
+continuously:
+	latexmk ${FLAGS} -pvc ${DOCUMENT}.tex
+
+clean:
+	latexmk -C ${FLAGS} ${DOCUMENT}.tex
+	rm -fv ${DOCUMENT}.bbl

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# OpenFOAM Journal: LaTeX Template
+
+This is the official LaTeX Template for the [OpenFOAM Journal](https://journal.openfoam.com/).
+
+## Building
+
+On a Linux system, you can build the template from your terminal:
+
+```shell
+make
+```
+
+This will build `ofj-template.pdf` from `ofj-template.tex` once, using [latexmk](https://www.ctan.org/pkg/latexmk/).
+
+While writing your publication, you may prefer to continuously build it with
+
+```shell
+make continuously
+```
+
+which passes the `-pvc` flag to latexmk.


### PR DESCRIPTION
Depends on #4, only merge after that.

This PR adds a GitHub Actions workflow to build the template. This is mainly useful for contributions: one does not need to argue _"it works on my machine!"_ anymore, as GitHub can automatically build the code.

Everything is running in a container made with the public Docker image [tumi5/latex](https://hub.docker.com/r/tumi5/latex), which we are developing and using in our chair at TUM ([source on GitHub](https://github.com/TUM-I5/latex-docker)). This is a very slim image that contains exactly what we also need here. One could even make a dedicated image for the Journal, but I don't think there is any particular reason to do this now.

When the job succeeds, it also uploads the PDF artifact. When the job fails, it uploads the LaTeX log file for inspection.

Note that the package `texlive-fonts-extra` is only needed for a potentially unused feature (see upcoming PR).