### PR TITLE
Footnotes: Use numbers instead of symbols

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -46,7 +46,6 @@
 \usepackage{setspace}
 \usepackage{lineno}
 \usepackage{color}
-\usepackage[symbol]{footmisc}
 \usepackage[dvipsnames,svgnames,x11names]{xcolor}
 \usepackage{orcidlink}
 \usepackage{cite}


### PR DESCRIPTION
With the current setup, footnotes are typeset with symbols. Apart from this being a bit unusual nowadays, this [limits the number of footnotes](https://ftp.cc.uoc.gr/mirrors/CTAN/macros/latex/contrib/footmisc/footmisc-doc.pdf) a paper can have, to the number of available symbols (not much more than 10). 

I understand that the original motivation for this was to not mix the footnotes on the first page with the affiliations of authors. I would argue that this is mainly something that should be fixed in the list of affiliations, if it is a problem at all (I guess most people would not miss the affiliations list directly under the names, before thinking of looking at the bottom of the page).

This PR removes the `footmisc` package, essentially falling back to the default arabic enumeration of footnotes.

Before:

![Screenshot from 2022-08-16 10-45-33](https://user-images.githubusercontent.com/4943683/184829385-1930e218-7492-4a65-acdd-c8a19f1c4853.png)

After:

![Screenshot from 2022-08-16 10-50-18](https://user-images.githubusercontent.com/4943683/184829429-ed229415-a0b5-43e6-836c-b4a4ece20e2a.png)

If you are not satisfied with this solution, there are also alternatives, such as making the symbols sequence restart in every page. But this would then be tricky for reviews, as one would need to refer to both the page and the footnote.