### PR TITLE
Add review mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,20 @@ jobs:
       uses: actions/checkout@v2
     - name: Build template
       run: make
+    - name: Build template in review mode
+      run: make review
     - name: Upload log files, if building failed
       uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: log files
-        path: ofj-template.log
+        path: |
+          ofj-template.log
+          ofj-template-review.log
     - name: Upload resulting PDF
       uses: actions/upload-artifact@v3
       with:
         name: template pdf
         path: |
           ofj-template.pdf
+          ofj-template-review.pdf

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ all:
 continuously:
 	latexmk ${FLAGS} -pvc ${DOCUMENT}.tex
 
+review:
+	latexmk ${FLAGS} ${DOCUMENT}-review.tex
+
 clean:
 	latexmk -C ${FLAGS} ${DOCUMENT}.tex
-	rm -fv ${DOCUMENT}.bbl
+	latexmk -C ${FLAGS} ${DOCUMENT}-review.tex
+	rm -fv ${DOCUMENT}.bbl ${DOCUMENT}-review.bbl

--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ make continuously
 ```
 
 which passes the `-pvc` flag to latexmk.
+
+To prepare a review version of your manuscript, you can run
+
+```shell
+make review
+```
+
+which enables double line spacing and excludes some identifying information (authors and affiliations, repository, acknowledgements). In case you rename `ofj-template.tex`, you need to also adjust the name of the file included in `ofj-template-review.tex`.

--- a/ofj-template-review.tex
+++ b/ofj-template-review.tex
@@ -1,0 +1,7 @@
+% Build the main .tex file, defining the \review variable.
+% This will enable review mode, which:
+% - applies double spacing
+% - hides the author names, affiliations, and contributor roles
+% - hides the repository
+% - hides the acknowledgements
+\def\review{1} \input{ofj-template.tex}

--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -68,13 +68,21 @@
 
 %    Please enter your OpenFOAM version
 \OpenFOAMversions{\OF v20xx}
+
+%    Code repository (hidden in review)
+\ifdefined\review
+\Repository{}
+\else
 %    Please enter your repository - for final version
 \Repository{https://github.com/xxx}
+\fi
 
 \DOI{TBD} %leave for submission
 
-%    For review, use double spacing
-\doublespacing
+%    For review, use double spacing (build with 'make review')
+\ifdefined\review
+  \doublespacing
+\fi
 
 %-----------------------------------------------------------------------
 %      The manuscript starts here
@@ -90,8 +98,12 @@
 %    \title[short text for running head]{full title}
 \title[\OF Journal publication]{\OF Journal publication}
 
-
-%    Author information
+%    Author information - hide in review mode
+\ifdefined\review
+  \author{}
+  \address{}
+  \email{}
+\else
 %    Note: authors should not be defined for the review process as the review is double-blind
 %    Author names should be given as initials for forenames followed by the surname: see the examples below
 
@@ -116,6 +128,7 @@
 %\author{P. Murphy$^2$}
 %\address{$^2$Address2}
 %\email{Emailaddress2}
+\fi
 
 
 %-----------------------------------------------------------------------
@@ -214,6 +227,8 @@ This is a conclusion.
 %      Start with acknowledgements here
 %-----------------------------------------------------------------------
 
+\ifdefined\review
+\else
 %\section*{Acknowledgements}
 %
 %This is an example acknowledgements section and should only be included !after! the review process and before publication.
@@ -241,6 +256,7 @@ This is a conclusion.
 %funding acquisition, P.M.
 %All authors have read and agreed to the published version of the manuscript.
 %}
+\fi
 
 %-----------------------------------------------------------------------
 %      Start with appendices here


### PR DESCRIPTION
When preparing a paper, it makes sense to have all the elements in the document compiled by the authors, while it is required by the author guidelines to remove identifying information from the version submitted for review. At the same time, the review version needs to be compiled with double spacing. The typical solution to this is commenting-out the respective parts, before compiling a version specifically for the review.

This PR adds a `make review` target to the Makefile, allowing to comfortably build a version ready for review. This enables `\doublespacing` and excludes from the compiled document:

- Authors and affiliations
- Repository
- Acknowledgements
- Author contributions

Example comparison:

![Screenshot from 2022-12-04 12-38-30](https://user-images.githubusercontent.com/4943683/205488282-a4cbe910-fcdd-40c9-a557-87c7275a016c.png)

This closes #8 and works as explained there (essentially with preprocessor definitions).

Apart from adding the target to the `Makefile`, this PR:
- Adds instructions about the review mode to the `README.md`
- Adds the review version building and build artifact to the CI (GitHub Actions) workflow