### PR TITLE
Disable indentation of first paragraph of sections

### DIFF
--- a/ofjart.cls
+++ b/ofjart.cls
@@ -1034,7 +1034,7 @@
 \def\@startsection#1#2#3#4#5#6{%
  \if@noskipsec \leavevmode \fi
  \par \@tempskipa #4\relax
- \@afterindenttrue
+ \@afterindentfalse
  \ifdim \@tempskipa <\z@ \@tempskipa -\@tempskipa \@afterindentfalse\fi
  \if@nobreak \everypar{}\else
      \addpenalty\@secpenalty\addvspace\@tempskipa\fi


### PR DESCRIPTION
Closes #15, based on https://tex.stackexchange.com/a/137400/27863. This is rather subjective, so you probably want to make sure that this what you want.

Compare the before and after:

![Screenshot from 2022-12-04 13-49-15](https://user-images.githubusercontent.com/4943683/205491723-3ded2c0e-a4ae-4b9f-bfed-b02a498eb161.png)

(note that the subsection paragraph starts in the same line anyway)