### PR TITLE
Suggest \autoref instead of hard-coded \ref

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -155,7 +155,7 @@ We shall consider the specific transport property $\Q$ and note that its spatial
     \ddt{}(\rho \Q) + \div(\rho \Q \U) - \Gamma_{\Q}\laplacian\Q - S_\Q(\Q) = 0.
     \label{eq:genTransEq}
 \end{align}
-Herein, $\Q=\Q(\xt)$ is an arbitrary general intensive physical quantitity, e.g., a fluid property (scalar or tensor of any rank). Thus, \eqref{eq:genTransEq} is often referred to as generic transport equation.
+Herein, $\Q=\Q(\xt)$ is an arbitrary general intensive physical quantitity, e.g., a fluid property (scalar or tensor of any rank). Thus, \autoref{eq:genTransEq} is often referred to as generic transport equation.
 
 \OF (Open Field Operation And Manipulation) is a flexible and mature C++ Class Library for Computational Continuum Mechanics (CCM) and Multiphysics. Its Object-Oriented-Programming (OOP) paradigm enables to \emph{mimic data types and basic operations} of CCM using top-level syntax as close as possible to the conventional mathematical notation \emph{for tensors and partial differential equations}:
 \begin{lstlisting}[emph={ddt,div,laplacian}]
@@ -168,7 +168,7 @@ solve
   Sphi
 );
 \end{lstlisting}
-Beside providing \OF code itself, spatial and temporal discretisation of Eq.\ \ref{eq:genTransEq} can be also described in a precise and concise manner using the finite-volume notation\, \cite{Weller1998} - see Tab.\ \ref{tab:FiniteVolumeNotation}.
+Beside providing \OF code itself, spatial and temporal discretisation of \autoref{eq:genTransEq} can be also described in a precise and concise manner using the finite-volume notation\, \cite{Weller1998} - see \autoref{tab:FiniteVolumeNotation}.
 
 \begin{table}
         \caption{Finite Volume Notation}
@@ -195,7 +195,7 @@ Beside providing \OF code itself, spatial and temporal discretisation of Eq.\ \r
 
 \section{Theoretical backgroud}
 
-Text in this section. Here is an examplary figure \ref{fig:example}.
+Text in this section. Here is an examplary figure (\autoref{fig:example}).
 
 %    Figure insertion; default placement is top; if the figure occupies
 %    more than 75% of a page, the [p] option should be specified.


### PR DESCRIPTION
Instead of writing:

```tex
Eq.\ \ref{eq:genTransEq}
Tab.\ \ref{tab:FiniteVolumeNotation}
figure \ref{fig:example}
```

explicitly (which can be tricky to update or keep consistent), one can just use `\autoref` from the already included/required package [hyperref](https://ctan.org/pkg/hyperref):

```tex
\autoref{eq:genTransEq}
\autoref{tab:FiniteVolumeNotation}
\autoref{fig:example}
```

this currently leads to `Equation 1`, `Table 1`, and `Figure 1`. Note that these are configurable, e.g., with `\def\tableautorefname{table}` (not applied here, just documenting the option, but I would favor the full-lowercase `figure` and `table`, as they don't break the reading flow).

This PR replaces all explicit `\ref` statements in the template with `\autoref`, to encourage using it.

![Screenshot from 2022-12-04 14-20-57](https://user-images.githubusercontent.com/4943683/205492869-aee1aa39-6b0d-4a6b-8244-5bf92ea1b586.png)
