### PR TITLE
Remove enforcement of uppercase in title

### DIFF
--- a/ofjart.cls
+++ b/ofjart.cls
@@ -796,7 +796,6 @@
 \def\@settitle{\begin{center}%
   \baselineskip14\p@\relax
     \bfseries
-\uppercasenonmath\@title
   \@title
   \end{center}%
 }


### PR DESCRIPTION
Closes #19, as described there. Effect:

![Screenshot from 2022-12-04 15-21-20](https://user-images.githubusercontent.com/4943683/205496539-435bea01-d1dc-4ce3-b201-8bc8f63ddbbb.png)

This only fixes the title (most important issue, in my opinion), but I can also try to fix the section headings and/or the author names, if you agree with this style change.