### PR TITLE
Replace suggestion for author names with initials

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -93,7 +93,7 @@
 
 %    Author information
 %    Note: authors should not be defined for the review process as the review is double-blind
-%    Author names should be given as initials for forenames followed by the surname: see the examples below
+%    Author names should be given as firstname followed by surname: see the examples below
 
 %    Only \author and \address are required; other information is
 %    optional.  Remove any unused author tags.
@@ -103,17 +103,17 @@
 %    Corresponding author information
 %    Indicate the corresponding author with an asteriks
 %    You can optionally add an Orcid link
-\author{M. Jersey$^{1,*}$\orcidlink{0000-1234-5678-0000}}
+\author{Maria Jersey$^{1,*}$\orcidlink{0000-1234-5678-0000}}
 \address{$^1$Address1}
 \email{Emailaddress1}
 
 %    Author two information
-\author{J. Smith$^2$}
+\author{John Smith$^2$}
 \address{$2$Address2} % not needed if the same as author 1
 \email{Emailaddress2}
 
 %   Author three information
-%\author{P. Murphy$^2$}
+%\author{Philip Murphy$^2$}
 %\address{$^2$Address2}
 %\email{Emailaddress2}
 


### PR DESCRIPTION
This replaces the comment and placeholder names to include the full name.

Closes #18, as explained there.