### PR TITLE
Cleanup merge artifacts from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ make continuously
 
 which passes the `-pvc` flag to latexmk.
 
-=======
 ## Review Version
 
 To prepare a review version of your manuscript, you can run
@@ -33,7 +32,6 @@ make review
 
 which enables double line spacing and excludes some identifying information (authors and affiliations, repository, acknowledgements). In case you rename `ofj-template.tex`, you need to also adjust the name of the file included in `ofj-template-review.tex`.
 
-=======
 ## Contributing
 
 Feel free to [open an issue](https://github.com/OpenFOAM-Journal/paperLatexTemplate/issues) explaining any problems or feature requests. Ideally, it would really help if you could directly [propose changes in a pull request](https://github.com/OpenFOAM-Journal/paperLatexTemplate/pulls) from your fork ([read how](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)). Describe your contribution in detail in the PR and try to use concise and descriptive commit messages. To keep the history clean, squash multiple related commits into one and update your branch with a force-push.


### PR DESCRIPTION
The `README.md` file currently contains two `=======`, most probably as a result of merging in https://github.com/OpenFOAM-Journal/paperLatexTemplate/commit/90c690de4c18429d35a6cf37290804814f0b8bcf#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

When resolving Git conflicts, Git will use these lines to separate the two versions. They are not part of the Markdown syntax.

This PR removes these.