### PR TITLE
Set options hang and flushmargin for footmisc

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -47,6 +47,7 @@
 \usepackage{lineno}
 \usepackage{color}
 \usepackage[dvipsnames,svgnames,x11names]{xcolor}
+\usepackage[hang,flushmargin]{footmisc}
 \usepackage{orcidlink}
 \usepackage{cite}
 


### PR DESCRIPTION
Fixes #22. I cannot reproduce it exactly on the template anymore, but I still reproduce it on another document that uses this template. Going over previous articles, [this one](https://journal.openfoam.com/index.php/ofj/article/view/49) seems to have the same problem.

In #10, I removed the explicit inclusion of [footmisc](https://ctan.org/pkg/footmisc), as we did not need to specify symbols as footnote marks anymore. However, to set the correct options, I need to restore the explicit `\usepackage{footmisc}`.

From the footmisc documentation:

![Screenshot from 2023-01-28 15-20-42](https://user-images.githubusercontent.com/4943683/215272399-47adf3fc-49e7-441d-a1c8-d4a187824951.png)

Without this change (in the template):

![Screenshot from 2023-01-28 15-41-35](https://user-images.githubusercontent.com/4943683/215272623-1427a45d-842d-4f40-abc1-a4928bdb4af5.png)

With this change (in the template):

![Screenshot from 2023-01-28 15-41-05](https://user-images.githubusercontent.com/4943683/215272595-2a16f833-1715-481b-a851-01f345d9e77c.png)


