### PR TITLE
Add article type to artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,5 @@ jobs:
       with:
         name: template pdf
         path: |
-          ofj-template.pdf
-          ofj-template-review.pdf
+          ofj-template_SetTypeInMakefile.pdf
+          ofj-template_SetTypeInMakefile-review.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,28 @@
+# Set the name of your project (looks for DOCUMENT.tex)
 DOCUMENT = ofj-template
+
+# Choose your article type (comment / uncomment respectively)
+TYPE     = SetTypeInMakefile
+# TYPE     = FullPaper
+# TYPE     = TNote
+# TYPE     = RevPaper
+
+JOBNAME  = ${DOCUMENT}_${TYPE}
+
 FLAGS    = -pdf -halt-on-error
 
-.PHONY:all continuously clean
+.PHONY:all continuously review clean
 
 all:
-	latexmk ${FLAGS} ${DOCUMENT}.tex
+	latexmk ${FLAGS} ${DOCUMENT}.tex -jobname=${JOBNAME}
 
 continuously:
-	latexmk ${FLAGS} -pvc ${DOCUMENT}.tex
+	latexmk ${FLAGS} -pvc ${DOCUMENT}.tex -jobname=${JOBNAME}
 
 review:
-	latexmk ${FLAGS} ${DOCUMENT}-review.tex
+	latexmk ${FLAGS} ${DOCUMENT}-review.tex -jobname=${JOBNAME}-review
 
 clean:
-	latexmk -C ${FLAGS} ${DOCUMENT}.tex
-	latexmk -C ${FLAGS} ${DOCUMENT}-review.tex
-	rm -fv ${DOCUMENT}.bbl ${DOCUMENT}-review.bbl
+	latexmk -C ${FLAGS} ${DOCUMENT}.tex -jobname=${JOBNAME}
+	latexmk -C ${FLAGS} ${DOCUMENT}-review.tex -jobname=${JOBNAME}-review
+	rm -fv ${JOBNAME}.bbl ${JOBNAME}-review.bbl

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ make continuously
 
 which passes the `-pvc` flag to latexmk.
 
+Set your project name and type in the beginning of the Makefile (see comments).
+
 =======
 ## Review Version
 

--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -149,7 +149,10 @@ This is the place for an abstract.
 \maketitle
 
 %   Line numbering should be enable for review and disabled for final version
-\linenumbers
+\ifdefined\review
+  \linenumbers
+\else
+\fi
 
 %-----------------------------------------------------------------------
 %      Start introduction here and continue with additional sections


### PR DESCRIPTION
Fixes #9.

As now documented in the `README.md`, the user has to select one of the available types, by commenting-out the default and commenting-in the respective type.

The default is `SetTypeInMakefile`, which will result in the file `ofj-template_SetTypeInMakefile.pdf` (also created by the CI). This should be enough of a clue for the user to look into the Makefile.

These are the available types, extending is trivial (add a new line):

```Makefile
# Choose your article type (comment / uncomment respectively)
TYPE     = SetTypeInMakefile
# TYPE     = FullPaper
# TYPE     = TNote
# TYPE     = RevPaper
```

The name of the source file is not affected (remains `ofj-template.tex`).

This also declares the `review` target as `PHONY` (forgotten in #12, not so important).