### PR TITLE
Replace metadata table by description

### DIFF
--- a/ofj.cls
+++ b/ofj.cls
@@ -110,11 +110,11 @@
   \bigskip
 
   % Software and Manuscript
-  \qquad\quad\begin{tabular}{ll}
-    \footnotesize\textbf{DOI}: & \href{https://doi.org/\theDOI}{\@DOI}\\
-    \footnotesize\textbf{Version(s)}: & \@OpenFOAMversions\\
-    \footnotesize\textbf{Repo}: & \href{\theRepository}{\@Repository}
-  \end{tabular}
+  \begin{description}
+    \item[DOI] \href{https://doi.org/\theDOI}{\@DOI}\\
+    \item[Version(s)] \@OpenFOAMversions\\
+    \item[Repo] \href{\theRepository}{\@Repository}
+  \end{description}
   \medskip
   \normalsize
   \dimen@34\p@ \advance\dimen@-\baselineskip


### PR DESCRIPTION
Fixes #3. May still need some work, if we really want to keep exactly the previous style.

Missing:
- `\footnotesize`
- fixed margin from the left

Somehow, both did not immediately work with the usual options, I need to investigate. I guess the template is redefining the `description` environment, which messes up stuff.

With previous solution (`tabular`):

![Screenshot from 2023-01-31 00-09-53](https://user-images.githubusercontent.com/4943683/215618342-5db0e82a-d541-453f-a50e-5916cdda92cb.png)

![Screenshot from 2023-01-31 00-09-22](https://user-images.githubusercontent.com/4943683/215618337-2cbbdbe6-78ab-4539-8e14-d5535c08980e.png)

With new solution (`description`):

![Screenshot from 2023-01-31 00-14-55](https://user-images.githubusercontent.com/4943683/215618389-e9ee6d9e-007a-480d-bb3d-ac434a22e9a9.png)

![Screenshot from 2023-01-31 00-15-10](https://user-images.githubusercontent.com/4943683/215618391-4cc945ee-ba52-4717-ae98-d408fd7ac3d5.png)
