### PR TITLE
Fix example of authors-affiliations

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -122,13 +122,10 @@
 
 %    Author two information
 \author{John Smith$^2$}
-\address{$2$Address2} % not needed if the same as author 1
-\email{Emailaddress2}
+\address{$^2$Address2} % a different address; not needed if the same as author 1
 
 %   Author three information
-%\author{Philip Murphy$^2$}
-%\address{$^2$Address2}
-%\email{Emailaddress2}
+\author{Philip Murphy$^2$} % reuses the address ^2 defined above
 \fi
 
 

--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -116,16 +116,16 @@
 %    Corresponding author information
 %    Indicate the corresponding author with an asteriks
 %    You can optionally add an Orcid link
-\author{Maria Jersey$^{1,*}$\orcidlink{0000-1234-5678-0000}}
+\author[M. Jersey]{Maria Jersey$^{1,*}$\orcidlink{0000-1234-5678-0000}}
 \address{$^1$Address1}
 \email{Emailaddress1}
 
 %    Author two information
-\author{John Smith$^2$}
+\author[J. Smith]{John Smith$^2$}
 \address{$^2$Address2} % a different address; not needed if the same as author 1
 
 %   Author three information
-\author{Philip Murphy$^2$} % reuses the address ^2 defined above
+\author[P. Murphy]{Philip Murphy$^2$} % reuses the address ^2 defined above
 \fi
 
 


### PR DESCRIPTION
Fixes #2.

- Fixes the address mark of the second author (should be `^2`, not just `2`).
- Enables the third author, who shares the affiliation of the second author.
- Removes the email address from the second author. While the second address makes sense to be shared (university), sharing email addresses sounds strange. In any case, only the corresponding author should probably have an email address on the paper.
- Adds further comments to help understand how this works.

Result:

![Screenshot from 2023-01-31 00-23-05](https://user-images.githubusercontent.com/4943683/215620190-c8fff2d1-045a-45ed-a809-7a1805d1a359.png)

