### PR TITLE
Remove or replace uppercase enforcement from elements

### DIFF
--- a/ofjart.cls
+++ b/ofjart.cls
@@ -1111,7 +1111,7 @@
   {\normalfont\centering}}
 \def\section{\@startsection{section}{1}%
   \z@{.7\linespacing\@plus\linespacing}{.5\linespacing}%
-  {\normalfont\scshape\centering}}
+  {\normalfont\bf\centering}}
 \def\subsection{\@startsection{subsection}{2}%
   \z@{.5\linespacing\@plus.7\linespacing}{-.5em}%
   {\normalfont\bfseries}}

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -1351,7 +1351,7 @@
 \newcommand{\fps@figure}{tbp}
 \newcommand{\fps@table}{tbp}
 \newcounter{figure}
-\def\@captionheadfont{\scshape}
+\def\@captionheadfont{\bfseries}
 \def\@captionfont{\normalfont}
 \def\ftype@figure{1}
 \def\ext@figure{lof}

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -848,7 +848,7 @@
       \parsep\z@ \@plus\p@
       \let\fullwidthdisplay\relax
     }%
-    \item[\hskip\labelsep\scshape\abstractname.]%
+    \item[\hskip\labelsep\bf\abstractname.]%
 }{%
   \endlist\egroup
   \ifx\@setabstract\relax \@setabstracta \fi

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -813,7 +813,7 @@
   \item\relax
   \author@andify\authors
   \def\\{\protect\linebreak}%
-  \MakeUppercase{\authors}%
+  \authors%
   \ifx\@empty\contribs
   \else
     ,\penalty-3 \space \@setcontribs

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -530,7 +530,7 @@
   \def\address##1##2{\begingroup
     \par\addvspace\bigskipamount\indent
     \@ifnotempty{##1}{(\ignorespaces##1\unskip) }%
-    {\scshape\ignorespaces##2}\par\endgroup}%
+    {\ignorespaces##2}\par\endgroup}%
   \def\curraddr##1##2{\begingroup
     \@ifnotempty{##2}{\nobreak\indent\curraddrname
       \@ifnotempty{##1}{, \ignorespaces##1\unskip}\/:\space

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -600,7 +600,6 @@
   \@topnum\z@ % this prevents figures from falling at the top of page 1
   \@setcopyright
   \thispagestyle{firstpage}% this sets first page specifications
-  \shorttitle
   \ifx\@empty\shortauthors \let\shortauthors\shorttitle
   \else \andify\shortauthors
   \fi

--- a/ofjart.cls
+++ b/ofjart.cls
@@ -600,7 +600,7 @@
   \@topnum\z@ % this prevents figures from falling at the top of page 1
   \@setcopyright
   \thispagestyle{firstpage}% this sets first page specifications
-  \uppercasenonmath\shorttitle
+  \shorttitle
   \ifx\@empty\shortauthors \let\shortauthors\shorttitle
   \else \andify\shortauthors
   \fi
@@ -611,7 +611,7 @@
   \toks4{\def\\{ \ignorespaces}}% defend against questionable usage
   \edef\@tempa{%
     \@nx\markboth{\the\toks4
-      \@nx\MakeUppercase{\the\toks@}}{\the\@temptokena}}%
+      \@nx\the\toks@}{\the\@temptokena}}%
   \@tempa
   \endgroup
   \c@footnote\z@


### PR DESCRIPTION
Fixes #29 (@ofjournal)

Changes:

| Element       | Before     | After
|---------------|------------|------
| Author names  | UPPERCASE  | Normal
| Addresses     | SMALL CAPS | Normal
| Abstract name | SMALL CAPS | **Boldface**
| Sections      | SMALL CAPS | **Boldface** (centered, subsections left-aligned)
| Caption names | SMALL CAPS | **Boldface**
| Page header   | UPPERCASE  | Normal (footnotesize)

One could even use color to make some of these elements stand out or be clearer (e.g., gray for headings). I could not make this work so far, but I could use the [`fancyhdr`](https://ctan.org/pkg/fancyhdr) package. For other elements (e.g., captions and sections), one could even come up with a consistent color scheme, which could be seen as the "brand" of the paper. But I don't want to touch this here.

I am not completely sure if there can be any side-effects of my changes, as I don't completely understand the current code, but I am quite confident that they are fine.

Result: [PDF](https://github.com/OpenFOAM-Journal/paperLatexTemplate/files/10557769/ofj-template_SetTypeInMakefile.pdf)

Before: [PDF (before)](https://github.com/OpenFOAM-Journal/paperLatexTemplate/files/10557810/ofj-template_SetTypeInMakefile.pdf)

![Screenshot from 2023-02-01 15-07-09](https://user-images.githubusercontent.com/4943683/216065265-b889787e-b97a-4bb6-927e-698a0403f7ed.png)

---

![Screenshot from 2023-02-01 15-07-31](https://user-images.githubusercontent.com/4943683/216065274-8652ae5b-f49c-4c78-900f-0bf2b1dbf91e.png)

---

![Screenshot from 2023-02-01 15-07-41](https://user-images.githubusercontent.com/4943683/216065278-eec6bb9d-c8a9-4128-b7d1-20ed142ac0e9.png)
