### PR TITLE
For consistency, the second affiliation should also be superscript

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -122,7 +122,7 @@
 
 %    Author two information
 \author{John Smith$^2$}
-\address{$2$Address2} % not needed if the same as author 1
+\address{$^2$Address2} % not needed if the same as author 1
 \email{Emailaddress2}
 
 %   Author three information


### PR DESCRIPTION
@MakisH This seems like a trivial minor fix. Merge if you agree.