### PR TITLE
Update metadata labels

### DIFF
--- a/ofj.cls
+++ b/ofj.cls
@@ -112,8 +112,8 @@
   % Software and Manuscript
   \begin{description}
     \item[DOI] \href{https://doi.org/\theDOI}{\@DOI}\\
-    \item[Version(s)] \@OpenFOAMversions\\
-    \item[Repo] \href{\theRepository}{\@Repository}
+    \item[Results with version(s)] \@OpenFOAMversions\\
+    \item[Repository] \href{\theRepository}{\@Repository}
   \end{description}
   \medskip
   \normalsize


### PR DESCRIPTION
Continuing the discussion in #32 and in https://github.com/OpenFOAM-Journal/paperLatexTemplate/pull/27#issuecomment-1420455907, this PR updates the metadata labels.

After merging this and #32, it looks like there will be a moment without any (!) open issues or PRs in this repository. :rainbow: :sun_with_face: 

FYI @ofjournal @jmnobrega @eulerian-solutions @philipcardiff 

Example:

![Screenshot from 2023-02-08 13-01-24](https://user-images.githubusercontent.com/4943683/217524216-9fc974cb-8566-4b70-9b6c-fad23c6a9d50.png)

