### PR TITLE
Fix a scope in \maketitle

### DIFF
--- a/ofjart.cls
+++ b/ofjart.cls
@@ -610,7 +610,7 @@
   \toks4{\def\\{ \ignorespaces}}% defend against questionable usage
   \edef\@tempa{%
     \@nx\markboth{\the\toks4
-      \@nx\the\toks@}{\the\@temptokena}}%
+      \@nx{\the\toks@}}{\the\@temptokena}}%
   \@tempa
   \endgroup
   \c@footnote\z@


### PR DESCRIPTION
[2ee252](https://github.com/OpenFOAM-Journal/paperLatexTemplate/commit/2ee2527b0c55d0b56d1e10aaabdcc7f91756afb7) removed the `\MakeUppercase{}` from the page headers, but this led to an unexpected bug in a longer paper. A side-effect of `\MakeUppercase{}` was that the tokens at that place were only effective within the scope of `\MakeUppercase{}`.

This restores just the scope.
There seems to be no other instances of this issue.