### PR TITLE
Move hyperref loading to the end

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -51,6 +51,10 @@
 \usepackage{orcidlink}
 \usepackage{cite}
 
+% hyperref should be loaded last, to prevent conflicts with other packages
+% For example, to prevent this warning: https://tex.stackexchange.com/q/16268/27863
+\usepackage[colorlinks=true,linkcolor=black,anchorcolor=black,citecolor=black,filecolor=black,menucolor=black,runcolor=black,urlcolor=black]{hyperref}
+
 \newcommand{\authorcontributions}[1]{%
 \vspace{6pt}\noindent{\fontsize{9}{11.2}\selectfont\textbf{Author Contributions:} {#1}\par}}
 

--- a/ofj.cls
+++ b/ofj.cls
@@ -51,7 +51,6 @@
 
 \RequirePackage[margin=2.5cm]{geometry}
 \RequirePackage{booktabs}
-\RequirePackage[colorlinks=true,linkcolor=black,anchorcolor=black,citecolor=black,filecolor=black,menucolor=black,runcolor=black,urlcolor=black]{hyperref}
 \RequirePackage{graphicx}
 \RequirePackage{amsmath}
 \RequirePackage{algorithmic} %Typesetting complex algorithmic constructs

--- a/orcidlink.sty
+++ b/orcidlink.sty
@@ -24,7 +24,7 @@
 
 %% All I did was package up Milo's code on TeX.SE,
 %% see https://tex.stackexchange.com/a/445583/34063
-\RequirePackage{hyperref}
+% \RequirePackage{hyperref}
 \RequirePackage{tikz}
 
 \ProcessOptions\relax


### PR DESCRIPTION
Trying to resolve warnings in my document, I stumbled upon multiple occurrences of this warning:

```
name{Hfootnote.xx} has been referenced but does not exist, replaced by a fixed one.
```

Apparently, there is a [common good practice](https://tex.stackexchange.com/q/16268/27863) to include `hyperref` as the last package. Citing the [package documentation](https://ctan.org/pkg/hyperref), this is true:

![Screenshot from 2023-02-08 18-39-53](https://user-images.githubusercontent.com/4943683/217609129-49978f02-cf7b-45a1-963a-148aed23da6d.png)

This PR converts/move the `\Requirepackage{hyperref}` from the `ofj.cls` to a `\usepackage{hyperref}` directly inside `ofj-template.tex`, at the end of the packages list. Of course, a comment is guiding the user regarding this.
