### PR TITLE
Adjust autoref labels

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -55,6 +55,11 @@
 % For example, to prevent this warning: https://tex.stackexchange.com/q/16268/27863
 \usepackage[colorlinks=true,linkcolor=black,anchorcolor=black,citecolor=black,filecolor=black,menucolor=black,runcolor=black,urlcolor=black]{hyperref}
 
+% Labels for tables, figures, equantions
+\def\tableautorefname{Tab.}
+\def\figureautorefname{Fig.}
+\def\equationautorefname{Eqn.}
+
 \newcommand{\authorcontributions}[1]{%
 \vspace{6pt}\noindent{\fontsize{9}{11.2}\selectfont\textbf{Author Contributions:} {#1}\par}}
 


### PR DESCRIPTION
In https://github.com/OpenFOAM-Journal/paperLatexTemplate/pull/17, I replaced hard-coded `\ref{}` labels with `\autoref{}` (keeping its default labels).

Via email, @eulerian-solutions asked me to adjust these labels:

| **Before** | **After** |
| ---------- | --------- |
| Table 1    | Tab. 1    |
| Figure 1   | Fig. 1    |
| Equation 1 | Eqn. 1    |

This PR implements these suggestions. Result:

![Screenshot from 2023-02-24 14-26-02](https://user-images.githubusercontent.com/4943683/221191912-bd3053e1-5348-427e-bf0a-c750a118f5b7.png)
