### PR TITLE
Add xspace to \OF command

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -50,6 +50,7 @@
 \usepackage[hang,flushmargin]{footmisc}
 \usepackage{orcidlink}
 \usepackage{cite}
+\usepackage{xspace} % Don't remove spaces following \mbox{} etc
 
 % hyperref should be loaded last, to prevent conflicts with other packages
 % For example, to prevent this warning: https://tex.stackexchange.com/q/16268/27863
@@ -70,7 +71,7 @@
 % Copyright info - will be updated by the editor
 \copyrightinfo{2022}{The Authors. This work is an open access article under the {\color{blue}{\href{https://creativecommons.org/licenses/by-sa/4.0/}{CC BY-SA 4.0}}} license}
 %\numberwithin{equation}{section}%Please don't enable this for submission!
-\newcommand{\OF}[0]{OpenFOAM\textsuperscript{\textregistered} }
+\newcommand{\OF}[0]{OpenFOAM\textsuperscript{\textregistered}\xspace}
 
 %-----------------------------------------------------------------------
 %      Please modify the entries in this section according to your neeeds


### PR DESCRIPTION
Solves #38. (@ofjournal)

When defining new commands for placeholders, LaTeX does not correctly handle spaces at the end of the command. The package [xspace](https://ctan.org/pkg/xspace) adds or removes a space at the end, depending on the context. I have used this package already a lot in other texts.

Result:

![Screenshot from 2023-02-26 10-24-34](https://user-images.githubusercontent.com/4943683/221402751-81116a6d-2e91-4fda-b129-1413a64868a5.png)


