### PR TITLE
Use title case in the title; fix typos; explicitly point out Fig/Tab/Eqn

### DIFF
--- a/ofj-template.tex
+++ b/ofj-template.tex
@@ -69,7 +69,7 @@
 \let\paragraph\undefined
 
 % Copyright info - will be updated by the editor
-\copyrightinfo{2022}{The Authors. This work is an open access article under the {\color{blue}{\href{https://creativecommons.org/licenses/by-sa/4.0/}{CC BY-SA 4.0}}} license}
+\copyrightinfo{2024}{The Authors. This work is an open access article under the {\color{blue}{\href{https://creativecommons.org/licenses/by-sa/4.0/}{CC BY-SA 4.0}}} license}
 %\numberwithin{equation}{section}%Please don't enable this for submission!
 \newcommand{\OF}[0]{OpenFOAM\textsuperscript{\textregistered}\xspace}
 
@@ -110,7 +110,7 @@
 
 
 %    \title[short text for running head]{full title}
-\title[\OF Journal publication]{\OF Journal publication}
+\title[\OF Journal Publication  - Use Title Case]{\OF Journal Publication - Use Title Case}
 
 %    Author information - hide in review mode
 \ifdefined\review

--- a/parts/conclusion.tex
+++ b/parts/conclusion.tex
@@ -1,3 +1,3 @@
 \section{Conclusion}
 
-This is a conclusion.
+This is a conclusion. Notice how equations, tables and figures are referred to in the text as \autoref{eq:genTransEq}, \autoref{tab:FiniteVolumeNotation} and \autoref{fig:example}, respectively.

--- a/parts/introduction.tex
+++ b/parts/introduction.tex
@@ -10,12 +10,12 @@ This is the place for introduction.
 
 Example text:
 
-We shall consider the specific transport property $\Q$ and note that its spatial and temporal variation is governed by a second-order partical differential equation (PDE), viz.\
+We shall consider the specific transport property $\Q$ and note that its spatial and temporal variation is governed by a second-order partial differential equation (PDE), viz.\
 \begin{align}
     \ddt{}(\rho \Q) + \div(\rho \Q \U) - \Gamma_{\Q}\laplacian\Q - S_\Q(\Q) = 0.
     \label{eq:genTransEq}
 \end{align}
-Herein, $\Q=\Q(\xt)$ is an arbitrary general intensive physical quantitity, e.g., a fluid property (scalar or tensor of any rank). Thus, \autoref{eq:genTransEq} is often referred to as generic transport equation.
+Herein, $\Q=\Q(\xt)$ is an arbitrary general intensive physical quantity, e.g., a fluid property (scalar or tensor of any rank). Thus, \autoref{eq:genTransEq} is often referred to as a generic transport equation.
 
 \OF (Open Field Operation And Manipulation) is a flexible and mature C++ Class Library for Computational Continuum Mechanics (CCM) and Multiphysics. Its Object-Oriented-Programming (OOP) paradigm enables to \emph{mimic data types and basic operations} of CCM using top-level syntax as close as possible to the conventional mathematical notation \emph{for tensors and partial differential equations}:
 \begin{lstlisting}[emph={ddt,div,laplacian}]
@@ -28,7 +28,7 @@ solve
   Sphi
 );
 \end{lstlisting}
-Beside providing \OF code itself, spatial and temporal discretisation of \autoref{eq:genTransEq} can be also described in a precise and concise manner using the finite-volume notation\, \cite{Weller1998} - see \autoref{tab:FiniteVolumeNotation}.
+Besides providing \OF code itself, spatial and temporal discretisation of \autoref{eq:genTransEq} can also be described in a precise and concise manner using the finite-volume notation\, \cite{Weller1998} - see \autoref{tab:FiniteVolumeNotation}.
 
 \begin{table}
         \caption{Finite Volume Notation}

--- a/parts/section.tex
+++ b/parts/section.tex
@@ -1,6 +1,6 @@
 \section{Theoretical backgroud}
 
-Text in this section. Here is an examplary figure (\autoref{fig:example}).
+Text in this section. Here is an example figure (\autoref{fig:example}).
 
 %    Figure insertion; default placement is top; if the figure occupies
 %    more than 75% of a page, the [p] option should be specified.


### PR DESCRIPTION
Three proposed changes:
- Use title case in the paper title (since this is the format we now follow)
- Fix a few English language typos
- Explicitly point out how to use Fig./Tab/Eqn.