### PR TITLE
Update introduction.tex

### DIFF
--- a/parts/introduction.tex
+++ b/parts/introduction.tex
@@ -18,6 +18,7 @@ We shall consider the specific transport property $\Q$ and note that its spatial
 Herein, $\Q=\Q(\xt)$ is an arbitrary general intensive physical quantity, e.g., a fluid property (scalar or tensor of any rank). Thus, \autoref{eq:genTransEq} is often referred to as a generic transport equation.
 
 \OF (Open Field Operation And Manipulation) is a flexible and mature C++ Class Library for Computational Continuum Mechanics (CCM) and Multiphysics. Its Object-Oriented-Programming (OOP) paradigm enables to \emph{mimic data types and basic operations} of CCM using top-level syntax as close as possible to the conventional mathematical notation \emph{for tensors and partial differential equations}:
+\noindent\begin{minipage}{\linewidth}
 \begin{lstlisting}[emph={ddt,div,laplacian}]
 solve
 (
@@ -28,6 +29,7 @@ solve
   Sphi
 );
 \end{lstlisting}
+\end{minipage}
 Besides providing \OF code itself, spatial and temporal discretisation of \autoref{eq:genTransEq} can also be described in a precise and concise manner using the finite-volume notation\, \cite{Weller1998} - see \autoref{tab:FiniteVolumeNotation}.
 
 \begin{table}


### PR DESCRIPTION
Enclosed lstlisting in minipage to prevent code snippets being cut across several pages. Note: Not an ideal solution, especially if paper contains many long listings, the vertical spacing may be messed up.