### PR TITLE
CI: Upgrade actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,13 @@ jobs:
     container: tumi5/latex
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build template
       run: make
     - name: Build template in review mode
       run: make review
     - name: Upload log files, if building failed
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: log files
@@ -23,7 +23,7 @@ jobs:
           ofj-template.log
           ofj-template-review.log
     - name: Upload resulting PDF
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: template pdf
         path: |


### PR DESCRIPTION
Upgrade:

- `actions/checkout` from v2 to v4
- `actions/upload-artifact` from v3 to v4

Both for deprecation reasons.